### PR TITLE
Use path style instead of vhost

### DIFF
--- a/servicer_test.go
+++ b/servicer_test.go
@@ -89,7 +89,7 @@ func TestService_Get(t *testing.T) {
 					srv.config.Protocol, name, location, srv.config.Host),
 			)
 			return &http.Response{
-				StatusCode: http.StatusTemporaryRedirect,
+				StatusCode: http.StatusMovedPermanently,
 				Header:     header,
 			}, nil
 		}

--- a/utils.go
+++ b/utils.go
@@ -288,8 +288,7 @@ func (s *Service) detectLocation(name string) (location string, err error) {
 	defer func() {
 		err = s.formatError("detect_location", err, "")
 	}()
-
-	//url := fmt.Sprintf("%s://%s/%s:%d", s.config.Protocol , name , s.config.Host , s.config.Port)
+	
 	url := fmt.Sprintf("%s://%s:%d/%s", s.config.Protocol, s.config.Host, s.config.Port, name)
 
 	r, err := s.client.Head(url)

--- a/utils.go
+++ b/utils.go
@@ -289,14 +289,15 @@ func (s *Service) detectLocation(name string) (location string, err error) {
 		err = s.formatError("detect_location", err, "")
 	}()
 
-	url := fmt.Sprintf("%s://%s.%s:%d", s.config.Protocol, name, s.config.Host, s.config.Port)
+	//url := fmt.Sprintf("%s://%s.%s:%d", s.config.Protocol, name, s.config.Host, s.config.Port)
+	url := fmt.Sprintf("%s://%s/%s", s.config.Protocol, "qingstor.com" , name )
 
 	r, err := s.client.Head(url)
 	if err != nil {
 		return
 	}
-	if r.StatusCode != http.StatusTemporaryRedirect {
-		err = fmt.Errorf("head status is %d instead of %d", r.StatusCode, http.StatusTemporaryRedirect)
+	if r.StatusCode != http.StatusMovedPermanently {
+		err = fmt.Errorf("head status is %d instead of %d", r.StatusCode, http.StatusNotFound)
 		return
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -289,14 +289,14 @@ func (s *Service) detectLocation(name string) (location string, err error) {
 		err = s.formatError("detect_location", err, "")
 	}()
 	
-	url := fmt.Sprintf("%s://%s/%s", s.config.Protocol, "qingstor.com" , name )
+	url := fmt.Sprintf("%s://%s:%d/%s", s.config.Protocol, s.config.Host , s.config.Port , name )
 
 	r, err := s.client.Head(url)
 	if err != nil {
 		return
 	}
 	if r.StatusCode != http.StatusMovedPermanently {
-		err = fmt.Errorf("head status is %d instead of %d", r.StatusCode, http.StatusNotFound)
+		err = fmt.Errorf("head status is %d instead of %d", r.StatusCode, http.StatusMovedPermanently)
 		return
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -288,8 +288,9 @@ func (s *Service) detectLocation(name string) (location string, err error) {
 	defer func() {
 		err = s.formatError("detect_location", err, "")
 	}()
-	
-	url := fmt.Sprintf("%s://%s:%d/%s", s.config.Protocol, s.config.Host , s.config.Port , name )
+
+	//url := fmt.Sprintf("%s://%s/%s:%d", s.config.Protocol , name , s.config.Host , s.config.Port)
+	url := fmt.Sprintf("%s://%s:%d/%s", s.config.Protocol, s.config.Host, s.config.Port, name)
 
 	r, err := s.client.Head(url)
 	if err != nil {

--- a/utils.go
+++ b/utils.go
@@ -288,8 +288,7 @@ func (s *Service) detectLocation(name string) (location string, err error) {
 	defer func() {
 		err = s.formatError("detect_location", err, "")
 	}()
-
-	//url := fmt.Sprintf("%s://%s.%s:%d", s.config.Protocol, name, s.config.Host, s.config.Port)
+	
 	url := fmt.Sprintf("%s://%s/%s", s.config.Protocol, "qingstor.com" , name )
 
 	r, err := s.client.Head(url)


### PR DESCRIPTION
fix #1 
Change DNS style like `https://bucket_name.qingstor.com:XXXX`
to path style `https://qingstor.com:XXXX/bucket_name`

Change the return value of **301** for success, **404** for failure

Tested on my ubuntu 18.04 machine
![image](https://user-images.githubusercontent.com/57066972/116771078-20a02e80-aa7b-11eb-841e-64b51122d3cf.png)
